### PR TITLE
Removing unnecessary transitive dependencies

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,7 +18,5 @@
   ],
   "headers": "M5UnitJoystick2.h",
   "dependencies": {
-      "M5Unified": "*",
-      "M5GFX": "*"
   }  
 }

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Device Control
 url=https://github.com/m5stack/M5Unit-Joystick2.git
 architectures=esp32
 includes=M5UnitJoystick2.h
-depends=M5Unified,M5GFX
+depends=


### PR DESCRIPTION
Fixes https://github.com/m5stack/M5Unit-Joystick2/issues/2

M5Unified and M5GFX are defined as dependencies but never used.